### PR TITLE
allow value casting before saving to database

### DIFF
--- a/cucumber-blendle-steps.gemspec
+++ b/cucumber-blendle-steps.gemspec
@@ -22,9 +22,10 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'hyperresource'
   spec.add_dependency 'json_spec'
   spec.add_dependency 'minitest'
-  spec.add_dependency 'rspec-expectations'
   spec.add_dependency 'rack-test'
   spec.add_dependency 'rack'
+  spec.add_dependency 'rspec-expectations'
+  spec.add_dependency 'sequel'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'pry'

--- a/lib/cucumber/blendle/steps/model_steps.rb
+++ b/lib/cucumber/blendle/steps/model_steps.rb
@@ -1,27 +1,48 @@
 require 'active_support/core_ext/hash/keys'
 require 'active_support/core_ext/object/blank'
 require 'active_support/core_ext/string/inflections'
+require 'sequel'
 
-# rubocop:disable Lint/Eval
-# rubocop:disable Lint/UnusedBlockArgument
+# rubocop:disable Lint/Eval,Metrics/LineLength,Lint/UselessAssignment
 
 Given(/^the following (\S+) exist:$/) do |object, table|
   table.hashes.each do |row|
-    assert eval("#{object.singularize.capitalize}.create(row.symbolize_keys)")
-    step %(the following #{object.singularize} should exist:), table([row.keys, row.values])
+    hash = parse_row(row)
+
+    assert eval("#{object.singularize.capitalize}.create(hash)")
+    step %(the following #{object.singularize} should exist:), table([hash.keys, hash.values])
   end
 end
 
-Then(/^the (\S+) with (\S+) "([^"]*)" should( not)? exist$/) do |object, attribute, negate, value|
+Then(/^the (\S+) with (\S+)(?: \((\S+)\))? "([^"]*)" should( not)? exist$/) do |object, attribute, type, value, negate|
+  hash      = parse_row("#{attribute} (#{type})" => value)
   assertion = negate ? 'blank?' : 'present?'
 
-  assert eval("#{object.capitalize}.first(attribute.to_sym => value).#{assertion}")
+  assert eval("#{object.capitalize}.first(hash).#{assertion}"),
+         %(#{object.capitalize} not found \(#{attribute}: #{value}\))
 end
 
 Then(/^the following (\S+) should( not)? exist:$/) do |object, negate, table|
   assertion = negate ? 'blank?' : 'present?'
 
   table.hashes.each do |row|
-    assert eval("#{object.capitalize}.first(row.symbolize_keys).#{assertion}")
+    hash = parse_row(row)
+
+    assert eval("#{object.capitalize}.first(hash).#{assertion}")
   end
+end
+
+def parse_row(row)
+  hash = row.map do |attribute, value|
+    value = case attribute[/\s\((\w+)\)$/, 1]
+            when 'Array'
+              Sequel.pg_array(eval(value))
+            else
+              value
+            end
+
+    [attribute.to_s.split.first.to_sym, value]
+  end
+
+  Hash[hash]
 end


### PR DESCRIPTION
Allows for:

``` gherkin
Given the following experiments exist:
  | uid        | segmentation (Array) |
  | helloworld | [80, 20]             |

And the experiment with segmentation (Array) "[80, 20]" should exist

And the following experiment should exist:
  | uid        | segmentation (Array) |
  | helloworld | [70, 30]             |
```

_we can extend this for other types in the future, for now, `Array` is supported, everything else is simply taken "as is" (ie: string)_
