### PR TITLE
Modified query to avoid Sequel deprecation warnings

### DIFF
--- a/lib/cucumber/blendle/steps/model_steps.rb
+++ b/lib/cucumber/blendle/steps/model_steps.rb
@@ -138,14 +138,14 @@ def parse_row(row, object_name)
 end
 
 def row_finder(klass, hash)
-  ext = 'where'
+  ext = ''
   query = hash.each_with_object({}) do |(key, value), q|
     if defined?(Sequel::Postgres::JSONBHash) && value.is_a?(Sequel::Postgres::JSONBHash)
-      ext = "where { Sequel.pg_jsonb(:#{key}).contains(#{value}) }"
+      ext = ".where { Sequel.pg_jsonb(:#{key}).contains(#{value}) }"
     else
       q[key] = value
     end
   end
 
-  eval "#{klass}.#{ext}.first(query)"
+  eval "#{klass}#{ext}.first(query)"
 end


### PR DESCRIPTION
Modified query to avoid Sequel deprecation warning line noise:

```
SEQUEL DEPRECATION WARNING: Passing no arguments and no block to a filtering method is deprecated and will be removed in Sequel 5.  Include at least one argument or a block when calling a filtering method.
```

![selection_314](https://user-images.githubusercontent.com/39518/29517855-40c0c246-8677-11e7-8172-1d91ae69a337.png)
