### PR TITLE
Fix ActiveSupport deprecation warnings

### DIFF
--- a/lib/cucumber/blendle/steps/model_steps.rb
+++ b/lib/cucumber/blendle/steps/model_steps.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
-require 'active_support/core_ext/hash/keys'
-require 'active_support/core_ext/hash/compact'
-require 'active_support/core_ext/object/blank'
-require 'active_support/core_ext/string/inflections'
+require 'active_support/all'
 require 'chronic'
 require 'sequel'
 

--- a/lib/cucumber/blendle/version.rb
+++ b/lib/cucumber/blendle/version.rb
@@ -6,6 +6,6 @@ module Cucumber
   # This module defines default steps used by all of Blendle Ruby projects.
   #
   module BlendleSteps
-    VERSION = '0.9.4'
+    VERSION = '0.9.5'
   end
 end


### PR DESCRIPTION
Newer versions of activesupport show a warning when loading
hash/compact, since it is part of Ruby 2.5+. Most of our projects are on
newer versions than that, but just to ensure compatibility it seems
easier to just let ActiveSupport figure out what to load. I think the
performance overhead is negligible here.